### PR TITLE
addes is_wrapper parameter to documentation

### DIFF
--- a/modules/riseBidAdapter.md
+++ b/modules/riseBidAdapter.md
@@ -25,6 +25,8 @@ The adapter supports Video(instream).
 | `placementId` | optional | String |  A unique placement identifier  | "12345678"
 | `testMode` | optional | Boolean |  This activates the test mode  | false
 | `rtbDomain` | optional | String |  Sets the seller end point  | "www.test.com"
+| `is_wrapper` | private | Boolean |  Please don't use unless your account manager asked you to  | false
+
 
 # Test Parameters
 ```javascript

--- a/test/spec/modules/riseBidAdapter_spec.js
+++ b/test/spec/modules/riseBidAdapter_spec.js
@@ -118,9 +118,11 @@ describe('riseAdapter', function () {
     });
 
     it('sends the is_wrapper parameter to ENDPOINT via POST', function() {
-      bidRequests[0].params.isWrapper = isWrapper;
+      const bidderRequestWithIsWrapper = Object.assign({isWrapper}, bidderRequest);
       const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.bids[0].is_wrapper).to.equal(isWrapper);
+      expect(request.data.params).to.be.an('object');
+      expect(request.data.params).to.have.property('is_wrapper');
+      expect(request.data.params.is_wrapper).to.equal(false);
     });
 
     it('sends bid request to ENDPOINT via POST', function () {

--- a/test/spec/modules/riseBidAdapter_spec.js
+++ b/test/spec/modules/riseBidAdapter_spec.js
@@ -109,7 +109,6 @@ describe('riseAdapter', function () {
     const api = [1, 2];
     const mimes = ['application/javascript', 'video/mp4', 'video/quicktime'];
     const protocols = [2, 3, 5, 6];
-    const isWrapper = false;
 
     it('sends the placementId to ENDPOINT via POST', function () {
       bidRequests[0].params.placementId = placementId;
@@ -118,7 +117,6 @@ describe('riseAdapter', function () {
     });
 
     it('sends the is_wrapper parameter to ENDPOINT via POST', function() {
-      const bidderRequestWithIsWrapper = Object.assign({isWrapper}, bidderRequest);
       const request = spec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.params).to.be.an('object');
       expect(request.data.params).to.have.property('is_wrapper');

--- a/test/spec/modules/riseBidAdapter_spec.js
+++ b/test/spec/modules/riseBidAdapter_spec.js
@@ -109,11 +109,18 @@ describe('riseAdapter', function () {
     const api = [1, 2];
     const mimes = ['application/javascript', 'video/mp4', 'video/quicktime'];
     const protocols = [2, 3, 5, 6];
+    const isWrapper = false;
 
     it('sends the placementId to ENDPOINT via POST', function () {
       bidRequests[0].params.placementId = placementId;
       const request = spec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.bids[0].placementId).to.equal(placementId);
+    });
+
+    it('sends the is_wrapper parameter to ENDPOINT via POST', function() {
+      bidRequests[0].params.isWrapper = isWrapper;
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.bids[0].is_wrapper).to.equal(isWrapper);
     });
 
     it('sends bid request to ENDPOINT via POST', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
